### PR TITLE
fix: Fix method to ensure french website version

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -136,8 +136,12 @@ class TemplateContentScript extends ContentScript {
 
   async authWithoutCredentials() {
     await this.goto(BASE_URL)
-    await this.waitForElementInWorker('.murray__Select__OptionButton')
-    await this.runInWorker('ensureFrenchWebsiteVersion')
+    await this.waitForElementInWorker('.CountrySwitcher')
+    const isFrench = await this.runInWorker('ensureFrenchWebsiteVersion')
+    if(!isFrench){
+      await this.goto('https://alan.com/')
+      await this.waitForElementInWorker('.CountrySwitcher')
+    }
     await this.waitForElementInWorker('a[href="/login"]')
     await this.clickAndWait('a[href="/login"]', 'a')
     await this.waitForElementInWorker('a')
@@ -234,12 +238,11 @@ class TemplateContentScript extends ContentScript {
   }
 
   ensureFrenchWebsiteVersion(){
-    const languageList = document.querySelectorAll('.murray__Select__OptionButton')
-    for (const language of languageList){
-      if (language.textContent.includes('Fran')){
-        language.click()
-        break
-      }
+    const locationHref = document.location.href
+    if(locationHref !== 'https://alan.com/'){
+      return false
+    }else{
+      return true
     }
   }
 


### PR DESCRIPTION
Website have blocked javscript click on the countrySwitcher element so the method to ensure we are on the french website version has been change accordingly. We now check the `document.location.href` as it is different depending on the chosen language and force it to the french version if on the wrong url.