### PR TITLE
[SCR-801] fix: Remove unecessary call

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -181,7 +181,6 @@ class TemplateContentScript extends ContentScript {
       contentType: 'application/pdf',
       qualificationLabel: 'health_invoice'
     })
-    await this.bridge.call('getExistingFilesIndex', true)
     await this.saveBills(documents.bills, {
       context,
       keys: ['vendorRef', 'beneficiary', 'date'],


### PR DESCRIPTION
The calling of `getExistingFilesIndex` is not necessary anymore, and provoke the crash of the connector when attempting it.

This is not needed anymore as it was done for past optimisation that has been resolved now.