### PR TITLE
[SCR-847] fix: Rename sessionStorage attribute for token payload

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -475,10 +475,11 @@ class AlanContentScript extends ContentScript {
   async fetchAlanApi(url, token) {
     this.log('info', 'fetchAlanApi starts')
     let urlToCheck = url
-    let tokenPayload = window.localStorage.tokenPayload
+    let tokenPayload = window.localStorage['@auth:tokenPayload']
     let beneficiaryId = tokenPayload
       .split(',')[1]
       .replace(/"/g, '')
+      .replace(/\\/g, '')
       .split(':')[1]
     if (urlToCheck.includes('${beneficiaryId}')) {
       urlToCheck = urlToCheck.replace('${beneficiaryId}', beneficiaryId)


### PR DESCRIPTION
They changed the attribute's name in the sessionStorage for the tokenPayload where the user id is found resulting in error when calling the API